### PR TITLE
PS-1144 Upgrade Ambra-Admin to work with NED-API

### DIFF
--- a/src/main/java/org/ambraproject/user/action/EditRolesAction.java
+++ b/src/main/java/org/ambraproject/user/action/EditRolesAction.java
@@ -39,6 +39,7 @@ public class EditRolesAction extends BaseAdminActionSupport {
   private AdminRolesService adminRolesService;
   private UserService userService;
   private List<UserRoleView> userRoles;
+  private Long userId;
   private String userAuthId;
   private String displayName;
   private String email;
@@ -53,12 +54,12 @@ public class EditRolesAction extends BaseAdminActionSupport {
    */
   public String execute() throws Exception {
 
-    if (userAuthId == null) {
-      addFieldError("authId", "authId is required");
+    if (userId == null) {
+      addFieldError("userId", "userId is required");
       return INPUT;
     }
 
-    loadCommonValues(this.userAuthId);
+    this.userRoles = adminRolesService.getAllRoles(userId);
 
     return SUCCESS;
   }
@@ -72,37 +73,25 @@ public class EditRolesAction extends BaseAdminActionSupport {
    */
   public String assignRoles() throws Exception {
 
-    if (userAuthId == null) {
-      addFieldError("authId", "authId is required");
+    if (userId== null) {
+      addFieldError("userId", "userId is required");
       return INPUT;
     }
 
-    UserProfile userProfile = userService.getUserByAuthId(this.userAuthId);
-
     //Revoke all roles and then reassign them
-    this.adminRolesService.revokeAllRoles(userProfile.getID());
+    this.adminRolesService.revokeAllRoles(userId);
 
     if(this.roleIDs != null) {
       for(Long roleID : roleIDs) {
-        this.adminRolesService.grantRole(userProfile.getID(), roleID);
+        this.adminRolesService.grantRole(userId, roleID);
       }
     }
 
-    loadCommonValues(this.userAuthId);
+    this.userRoles = adminRolesService.getAllRoles(userId);
 
     addActionMessage("Roles Updated Successfully");
 
     return SUCCESS;
-  }
-
-  private void loadCommonValues(String authid)
-  {
-    UserProfile userProfile = userService.getUserByAuthId(authid);
-    this.userRoles = adminRolesService.getAllRoles(userProfile.getID());
-
-    this.userAuthId = userProfile.getAuthId();
-    this.email = userProfile.getEmail();
-    this.displayName = userProfile.getDisplayName();
   }
 
   /**
@@ -121,6 +110,24 @@ public class EditRolesAction extends BaseAdminActionSupport {
    */
   public void setRoleIDs(final Long[] roleIDs) {
     this.roleIDs = roleIDs;
+  }
+
+  /**
+   * Struts setter for the user's profile ID
+   * @return
+   */
+  public void setUserId(Long userId)
+  {
+    this.userId = userId;
+  }
+
+  /**
+   * Get the user's profile ID
+   * @return
+   */
+  public Long getUserId()
+  {
+    return this.userId;
   }
 
   /**
@@ -151,6 +158,15 @@ public class EditRolesAction extends BaseAdminActionSupport {
   }
 
   /**
+   * Struts setter for the user's email
+   * @return
+   */
+  public void setEmail(String email)
+  {
+    this.email = email;
+  }
+
+  /**
    * Get the user's display name
    *
    * @return
@@ -160,6 +176,14 @@ public class EditRolesAction extends BaseAdminActionSupport {
     return this.displayName;
   }
 
+  /**
+   * Struts setter for the user's displayName
+   * @return
+   */
+  public void setDisplayName(String displayName)
+  {
+    this.displayName = displayName;
+  }
 
   @Required
   public void setAdminRolesService(AdminRolesService adminRolesService) {

--- a/src/main/webapp/templates/editUserRoles.ftl
+++ b/src/main/webapp/templates/editUserRoles.ftl
@@ -39,11 +39,17 @@
 
       <@s.form action="editRolesAssign" namespace="/" method="post" cssClass="ambra-form"
         method="post" title="Roles Form" name="userRoles">
+
+        <@s.hidden name="userId" />
         <@s.hidden name="userAuthId" />
+        <@s.hidden name="displayName" />
+        <@s.hidden name="email" />
+
           <#list userRoles as role>
             <@s.checkbox name="roleIDs" label="${role.roleName}" fieldValue="${role.ID}"
               value="${role.assigned?string}"/><br/>
           </#list>
+
         <br/>
         <@s.submit value="Save" />
       </@s.form>

--- a/src/main/webapp/templates/searchUser.ftl
+++ b/src/main/webapp/templates/searchUser.ftl
@@ -35,14 +35,16 @@
           <legend><b>User Profiles</b></legend>
           <ul>
             <#list users as user>
-              <@s.url id="editProfileByAdminURL" action="editProfileByAdmin" namespace="/" userAuthId="${user.authId}" includeParams="none"/>
-              <@s.url id="editRolesURL" action="editRoles" namespace="/" userAuthId="${user.authId}" includeParams="none"/>
+              <@s.url id="editRolesURL" action="editRoles" namespace="/" userId="${user.ID}"
+              displayName="${user.displayName}" email="${user.email}" userAuthId="${user.authId}"/>
+
               <li>
                 User: {Id: <b>${user.ID}</b>; User name: <b>${user.displayName!}</b>; Email: <b>${user.email!}</b>}
                 <#if permissions?seq_contains("MANAGE_ROLES")>
                   <@s.a href="%{editRolesURL}">Edit Roles</@s.a>
                 </#if>
               </li>
+
             </#list>
           </ul>
         </fieldset>


### PR DESCRIPTION
The NED-retrofitted Ambra-Admin does not query the userProfile table in Ambra-DB.

This new Ambra-Admin calls NED-API (via authId, displayName, or emailAddress) to get the userProfileID.

With userProfileID, Ambra-Admin can query the userProfileRoleJoinTable table in Ambra-DB for those roles that this userProfileID has been assigned to.